### PR TITLE
Update Package.swift file for SPM to work with Xcode 13.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,19 +3,19 @@
 import PackageDescription
 
 let package = Package(
-    name: "PointSDK",
+    name: "BDPointSDK",
     platforms: [
         .iOS(.v10)
     ],
     products: [
         .library(
-            name: "PointSDK",
-            targets: ["PointSDK"]
+            name: "BDPointSDK",
+            targets: ["BDPointSDK"]
         )
     ],
     targets:[
         .binaryTarget(
-            name: "PointSDK",
+            name: "BDPointSDK",
             path: "PointSDK/BDPointSDK.xcframework"
         )
     ]


### PR DESCRIPTION
Xcode 13.3 is somehow enforcing the binaryTarget name/path must be the same as the target. From the error message about the binary is not available in target PointSDK, I updated `targest` from `PointSDK` to  `BDPointSDK` and it works. It actually makes sense since we are not setting the target name `PointSDK` anywhere from the iOS SDK.

## Test Guide:
- Create a new project and add `BDPointSDK` package via Add Packages as usual, but choose branch `dn/spm-13.3-fix`.

Would love to see if it works on your end as well, @nehabluedot @jsprincep . 