### PR TITLE
Fix SPM issue in Xcode13.3 - artefacts not found

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,19 +3,19 @@
 import PackageDescription
 
 let package = Package(
-    name: "PointSDK",
+    name: "BDPointSDK",
     platforms: [
         .iOS(.v10)
     ],
     products: [
         .library(
-            name: "PointSDK",
-            targets: ["PointSDK"]
+            name: "BDPointSDK",
+            targets: ["BDPointSDK"]
         )
     ],
     targets:[
         .binaryTarget(
-            name: "PointSDK",
+            name: "BDPointSDK",
             path: "PointSDK/BDPointSDK.xcframework"
         )
     ]


### PR DESCRIPTION
Xcode 13.3 is somehow enforcing the binaryTarget name/path must be the same as the target. From the error message about the binary is not available in target PointSDK, I updated `targest` from `PointSDK` to  `BDPointSDK` and it works. It actually makes sense since we are not setting the target name `PointSDK` anywhere from the iOS SDK.

### Tested:
**Xcode 13.2.1:** 
- Carthage ✅
- Cocoapods ✅
- SPM ✅ 

**Xcode 13.3:** 
- Carthage ✅
- Cocoapods ✅
- SPM ✅

### Test Guide:
**SPM:**
- Create a new project and add `BDPointSDK` package via Add Packages as usual, but choose branch `dn/spm-fix`.
 
**Cocoapods:**
- Use github branch pod: `pod 'BluedotPointSDK', :git => 'https://github.com/Bluedot-Innovation/PointSDK-iOS.git', :branch => 'dn/spm-fix'`

**Carthage:**
- Use this in Carthfile: `github "datkinnguyen/PointSDK-iOS"` (have the same fix), as I needed to generate a release/tag on Github or else carthage always points to the latest release. Also tried `github “Bluedot-Innovation/PointSDK-iOS” “dn/spm-fix”` to point to the fix branch but got error `Dependency "PointSDK-iOS" has no shared framework schemes`. Open to suggestions to test this easier. You may also need to run `rm -rf ~/Library/Caches/org.carthage.CarthageKit` to delete Carthage cache.


Would love to see if it works on your end as well, @nehabluedot @jsprincep .