### PR TITLE
Release 16.0.0-rc8 into cocoapods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: release PointSDK
 # events but only for the master branch
 on:
   push:
-    branches: [ master, dev/16.0.0 ]
+    branches: [ master ]
     tags-ignore: 
       - '**'
 
@@ -70,30 +70,27 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         body_path: PointSDK/ReleaseNotes.md
-        # name: ${{ steps.notes.outputs.name }}
-        # tag_name: ${{ steps.semver.outputs.semver }}
-        name: 16.0.0-rc8
-        tag_name: 16.0.0-rc8
-        prerelease: true
+        name: ${{ steps.notes.outputs.name }}
+        tag_name: ${{ steps.semver.outputs.semver }}
         files: |
           PointSDK/BDPointSDK.xcframework.zip
           PointSDK/BDPointSDK.framework.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-#  pod:
-#    name: update pod
-#    runs-on: [macos-latest]
-#    timeout-minutes: 10
-#    needs: [release]
+    pod:
+        name: update pod
+        runs-on: [macos-latest]
+        timeout-minutes: 10
+        needs: [release]
     
-#    steps:
-#      # checkout current repository
-#      - uses: actions/checkout@v2
+    steps:
+        # checkout current repository
+        - uses: actions/checkout@v2
       
-#     # update pod
-#      - name: upload pod to cocoapods
-#        env: 
-#          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-#        run: |
-#          pod trunk push --allow-warnings BluedotPointSDK.podspec
+        # update pod
+        - name: upload pod to cocoapods
+        env: 
+            COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+            pod trunk push --allow-warnings BluedotPointSDK.podspec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,19 +78,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-    pod:
-        name: update pod
-        runs-on: [macos-latest]
-        timeout-minutes: 10
-        needs: [release]
+  pod:
+    name: update pod
+    runs-on: [macos-latest]
+    timeout-minutes: 10
+    needs: [release]
     
     steps:
-        # checkout current repository
-        - uses: actions/checkout@v2
+      # checkout current repository
+      - uses: actions/checkout@v2
       
-        # update pod
-        - name: upload pod to cocoapods
+      # update pod
+      - name: upload pod to cocoapods
         env: 
-            COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-            pod trunk push --allow-warnings BluedotPointSDK.podspec
+          pod trunk push --allow-warnings BluedotPointSDK.podspec


### PR DESCRIPTION
@andrew-stirling Could you please review if this is the proper step of our pre-release version of SDK. I couldn't find any doc about pre-releasing but the previous PRs.

This PR should release `Bluedot SDK 16.0.0-rc8` cocoapod by running the script:
`pod trunk push --allow-warnings BluedotPointSDK.podspec`
similar what we had in this [commit](https://github.com/Bluedot-Innovation/PointSDK-iOS/commit/1d8fb53c5925ae36798326e679d66c8dd04c25e3) when we released `Bluedot SDK 16.0.0-rc4` so we will have the rc8 version on [cocoapod](https://cocoapods.org/pods/BluedotPointSDK). It will allow us to use `pod install` to install the rc8 instead of rc4