### PR TITLE
Added ReleaseNotes to 17.0.1 and make the public release

### DIFF
--- a/PointSDK/ReleaseNotes.md
+++ b/PointSDK/ReleaseNotes.md
@@ -1,0 +1,9 @@
+# SDK Version 17.0.1
+## What’s New
+- Live Update engine support: We've added support for Apple's new Live Update engine, available in iOS 17 and above. This improvement enhances location tracking performance in background use cases, especially when users have granted "Always" location permissions.
+
+## What’s Improved
+- Better background performance on iOS 17+: Apps running on iOS 17 and above will now benefit from higher trigger rates and improved reliability when tracking in the background or when the device is locked.
+- Devices running iOS versions earlier than 17 will continue to use the previous background location tracking logic.
+ 
+Please refer to the detailed release notes and our updated documentation for more information. We appreciate your feedback and are here to assist you with any questions.


### PR DESCRIPTION
There were changes in GitHub related to creation xcframeworks that required to keep ReleaseNotes file separately.
We need to make an improvement to copy the ReleaseNotes to ./PointSDK folder of Public repo to make the public release.  I'll open a ticket 

Currently, we can manually add the ReleaseNotes and trigger the public release.

The ticket: https://bluedotinnovation.atlassian.net/browse/BD-6043